### PR TITLE
Github Action to extract and commit new Kitsune strings

### DIFF
--- a/.github/workflows/extract-strings.yml
+++ b/.github/workflows/extract-strings.yml
@@ -1,0 +1,55 @@
+name: Extract Kitsune Strings
+
+on:
+  schedule:
+  - cron: "0 2 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install deps
+        run: sudo apt-get install gettext
+
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Checkout Kitsune
+        uses: actions/checkout@v2
+        with:
+          repository: mozilla/kitsune
+
+      - name: Checkout locales
+        uses: actions/checkout@v2
+        with:
+          path: locale
+      
+      - name: Install python packages
+        run: pip install --no-cache-dir --require-hashes -r requirements/default.txt
+
+      - name: Setup environment
+        run: cp .env-test .env
+
+      - name: Remove unparsable templates
+        run: |
+          rm -r kitsune/kadmin/templates/kadmin
+          rm -r kitsune/search/templates/admin
+          rm -r kitsune/sumo/templates/admin
+
+      - name: Extract strings
+        run: python manage.py extract
+
+      - name: Merge strings
+        run: python manage.py merge
+
+      - name: Commit strings
+        run: |
+          cd locale
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -am "extract strings at $(date -Iseconds -u)"
+          git push https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git


### PR DESCRIPTION
I can't currently assign reviewers, so pinging you both: @akatsoulas @peiying2 

This is a github action which will checkout the master branch of kitsune, run the string extractor script, then commit the result back to the sumo-l10n repo.

Currently it's configured to run every weekday at 2AM UTC, but we can change that to whenever we want.

Here's an example of an action run: https://github.com/LeoMcA/sumo-l10n/runs/854440517?check_suite_focus=true

Here's what most commits will look like (when no changes have been made in Kitsune): https://github.com/LeoMcA/sumo-l10n/commit/7a50c4f2a2c77223f305f4545ab9743cec004636

And here's what a much larger commit looks like: https://github.com/LeoMcA/sumo-l10n/commit/0d734dc