### PR TITLE
add github action to run dennis lint on every commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint Strings
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Checkout locales
+        uses: actions/checkout@v2
+      
+      - name: Install dennis
+        run: pip install dennis~=0.9
+
+      - name: Run dennis
+        run: dennis-cmd lint --errorsonly .


### PR DESCRIPTION
After #30 I realized it would be incredibly trivial to get our linter running on every commit.

@akatsoulas r?

@peiying2 as written this will just add a status to each commit (shown as a green tick, or a red x), as can be seen on this deliberate error I introduced into my fork: https://github.com/LeoMcA/sumo-l10n/commit/88cd3a12b779e99e3ebc7d0b0fe6954e3a0ad76a

Clicking on the red x, details, will show the actual error: https://github.com/LeoMcA/sumo-l10n/runs/854900186

We could make this noisier if you wanted and trigger a slack (or, I guess, matrix) message.